### PR TITLE
clear/erase console line before logging by default

### DIFF
--- a/dlr/ki/logging/config.py
+++ b/dlr/ki/logging/config.py
@@ -27,7 +27,7 @@ def get_default_logging_dict(log_filepath: Optional[str] = None, ensure_log_dir:
         "formatters": {
             "console_formatter": {
                 "class": "dlr.ki.logging.formatter.colored_console.ColoredConsoleFormatter",
-                "format": "[%(levelcolor)s%(levelname)-8s%(colorreset)s] %(ansi.fg.grey)s[%(name)s][%(filename)s:%(lineno)d]%(ansi.fx.reset)s  %(message)s"  # noqa: E501
+                "format": "%(clearline)s[%(levelcolor)s%(levelname)-8s%(colorreset)s] %(ansi.fg.grey)s[%(name)s][%(filename)s:%(lineno)d]%(ansi.fx.reset)s  %(message)s"  # noqa: E501
             },
             "file_formatter": {
                 "class": "dlr.ki.logging.formatter.term_escape_code.TermEscapeCodeFormatter",

--- a/dlr/ki/logging/formatter/colored_console.py
+++ b/dlr/ki/logging/formatter/colored_console.py
@@ -5,6 +5,7 @@
 
 from ansi.colour.base import Graphic as AnsiGraphic
 import ansi.color as ansi
+from ansi.cursor import erase_line
 from copy import copy
 from logging import Formatter  # type: ignore [attr-defined]
 from typing import Dict
@@ -50,5 +51,6 @@ class ColoredConsoleFormatter(Formatter):
             ColoredConsoleFormatter.MAPPING["DEBUG"]
         )
         colored_record.colorreset = ansi.fx.reset
+        colored_record.clearline = erase_line() + "\r"
         colored_record.__dict__.update(self.ansi_dict)
         return super().format(colored_record)

--- a/examples/logging.conf
+++ b/examples/logging.conf
@@ -43,7 +43,7 @@ keys=consoleFormatter,fileFormatter
 
 [formatter_consoleFormatter]
 class=dlr.ki.logging.formatter.colored_console.ColoredConsoleFormatter
-format=[%(levelcolor)s%(levelname)-8s%(colorreset)s] %(ansi.fg.grey)s[%(name)s][%(filename)s:%(lineno)d]%(ansi.fx.reset)s  %(message)s
+format=%(clearline)s[%(levelcolor)s%(levelname)-8s%(colorreset)s] %(ansi.fg.grey)s[%(name)s][%(filename)s:%(lineno)d]%(ansi.fx.reset)s  %(message)s
 
 [formatter_fileFormatter]
 class=dlr.ki.logging.formatter.term_escape_code.TermEscapeCodeFormatter

--- a/examples/logging.yml
+++ b/examples/logging.yml
@@ -36,7 +36,7 @@ handlers:
 formatters:
   console_formatter:
     class: dlr.ki.logging.formatter.colored_console.ColoredConsoleFormatter
-    format: '[%(levelcolor)s%(levelname)-8s%(colorreset)s] %(ansi.fg.grey)s[%(name)s][%(filename)s:%(lineno)d]%(ansi.fx.reset)s  %(message)s'
+    format: '%(clearline)s[%(levelcolor)s%(levelname)-8s%(colorreset)s] %(ansi.fg.grey)s[%(name)s][%(filename)s:%(lineno)d]%(ansi.fx.reset)s  %(message)s'
   file_formatter:
     class: dlr.ki.logging.formatter.term_escape_code.TermEscapeCodeFormatter
     format: '%(asctime)s [%(levelname)-8s] [%(name)s][%(filename)s:%(lineno)d]  %(message)s'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ name = "dlr-logging"  # Required
 #
 # For a discussion on single-sourcing the version, see
 # https://packaging.python.org/guides/single-sourcing-package-version/
-version = "0.0.4.dev0"  # Required
+version = "0.0.5.dev0"  # Required
 
 # This is a one-line description or tagline of what your project does. This
 # corresponds to the "Summary" metadata field:


### PR DESCRIPTION
By default, clear the current terminal line, before printing the log message.